### PR TITLE
Per-worker http session

### DIFF
--- a/alligator/__init__.py
+++ b/alligator/__init__.py
@@ -11,7 +11,7 @@ from nltk.corpus import stopwords
 # Load environment variables from .env file
 load_dotenv()
 
-MY_TIMEOUT = aiohttp.ClientTimeout(
+TIMEOUT = aiohttp.ClientTimeout(
     total=30,  # Total time for the request
     connect=5,  # Time to connect to the server
     sock_connect=5,  # Time to wait for a free socket

--- a/alligator/alligator.py
+++ b/alligator/alligator.py
@@ -60,7 +60,7 @@ class Alligator(DatabaseAccessMixin):
         save_output: bool = True,
         save_output_to_csv: bool = True,
         correct_qids: Dict[str, str | List[str]] | None = None,
-        http_session_limit: int = 50,
+        http_session_limit: int = 32,
         http_session_ssl_verify: bool = False,
         **kwargs,
     ) -> None:

--- a/alligator/alligator.py
+++ b/alligator/alligator.py
@@ -556,17 +556,17 @@ class Alligator(DatabaseAccessMixin):
         dataset_name: str,
         error_log_collection_name: str,
         input_collection_name: str,
-        ranker_model_path_str: str,
-        reranker_model_path_str: str,
-        ml_worker_batch_size_val: int,
+        ranker_model_path: str,
+        reranker_model_path: str,
+        ml_worker_batch_size: int,
         max_candidates_rerank: int,
-        top_n_cta_cpa_freq_val: int,
-        selected_features_list: List[str],
-        mongo_uri_val: str,
-        db_name_val: str,
+        top_n_cta_cpa_freq: int,
+        selected_features: List[str],
+        mongo_uri: str,
+        db_name: str,
     ):
         """Static method wrapper for ML workers, suitable for multiprocessing."""
-        model_path_to_use = ranker_model_path_str if stage == "rank" else reranker_model_path_str
+        model_path_to_use = ranker_model_path if stage == "rank" else reranker_model_path
         max_candidates_for_stage = -1 if stage == "rank" else max_candidates_rerank
 
         worker = MLWorker(
@@ -577,12 +577,12 @@ class Alligator(DatabaseAccessMixin):
             error_log_collection=error_log_collection_name,
             input_collection=input_collection_name,
             model_path=model_path_to_use,
-            batch_size=ml_worker_batch_size_val,
+            batch_size=ml_worker_batch_size,
             max_candidates_in_result=max_candidates_for_stage,
-            top_n_cta_cpa_freq=top_n_cta_cpa_freq_val,
-            features=selected_features_list,
-            mongo_uri=mongo_uri_val,
-            db_name=db_name_val,
+            top_n_cta_cpa_freq=top_n_cta_cpa_freq,
+            features=selected_features,
+            mongo_uri=mongo_uri,
+            db_name=db_name,
         )
         return worker.run(global_frequencies=global_frequencies)
 
@@ -677,14 +677,14 @@ class Alligator(DatabaseAccessMixin):
                 "dataset_name": self.dataset_name,
                 "error_log_collection_name": self._ERROR_LOG_COLLECTION,
                 "input_collection_name": self._INPUT_COLLECTION,
-                "ranker_model_path_str": self.ranker_model_path,
-                "reranker_model_path_str": self.reranker_model_path,
-                "ml_worker_batch_size_val": self.ml_worker_batch_size,
+                "ranker_model_path": self.ranker_model_path,
+                "reranker_model_path": self.reranker_model_path,
+                "ml_worker_batch_size": self.ml_worker_batch_size,
                 "max_candidates_rerank": self.max_candidates_in_result,
-                "top_n_cta_cpa_freq_val": self.top_n_cta_cpa_freq,
-                "selected_features_list": self.feature.selected_features,
-                "mongo_uri_val": self._mongo_uri,
-                "db_name_val": self._DB_NAME,
+                "top_n_cta_cpa_freq": self.top_n_cta_cpa_freq,
+                "selected_features": self.feature.selected_features,
+                "mongo_uri": self._mongo_uri,
+                "db_name": self._DB_NAME,
             }
 
             # First ML ranking stage

--- a/alligator/cli.py
+++ b/alligator/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import asyncio
 import time
 
 from dotenv import load_dotenv
@@ -10,7 +9,7 @@ from alligator import Alligator
 load_dotenv()
 
 
-async def main():
+def main():
     parser = ArgumentParser()
     parser.add_class_arguments(Alligator, "gator")
     parser.add_argument(
@@ -24,13 +23,10 @@ async def main():
     print("🚀 Starting the entity linking process...")
     tic = time.perf_counter()
     gator = Alligator(**args.gator)
-    try:
-        await gator.run()
-    finally:
-        await gator.close()
+    gator.run()
     toc = time.perf_counter()
     print(f"✅ Entity linking process completed in {toc - tic:0.4f} seconds.")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/alligator/cli.py
+++ b/alligator/cli.py
@@ -24,7 +24,10 @@ async def main():
     print("🚀 Starting the entity linking process...")
     tic = time.perf_counter()
     gator = Alligator(**args.gator)
-    await gator.run()
+    try:
+        await gator.run()
+    finally:
+        await gator.close()
     toc = time.perf_counter()
     print(f"✅ Entity linking process completed in {toc - tic:0.4f} seconds.")
 

--- a/alligator/ml.py
+++ b/alligator/ml.py
@@ -66,7 +66,7 @@ class MLWorker(DatabaseAccessMixin):
         global_frequencies: Tuple[
             Dict[Any, Counter] | None,
             Dict[Any, Counter] | None,
-            Dict[Any, Dict[Any, Counter] | None],
+            Dict[Any, Dict[Any, Counter]] | None,
         ] = (None, None, None),
     ) -> None:
         """Process candidates directly from input_collection"""

--- a/alligator/typing.py
+++ b/alligator/typing.py
@@ -27,7 +27,6 @@ class Entity:
     value: str
     row_index: Optional[int]
     col_index: str  # Stored as string for consistency
-    context_text: str
     correct_qids: Optional[List[str]] = None
     fuzzy: bool = False
 
@@ -43,8 +42,6 @@ class RowData:
     context_columns: List[str]
     correct_qids: Dict[str, List[str]]
     row_index: Optional[int]
-    context_text: str
-    row_hash: str
 
 
 @dataclass

--- a/eval/inference.py
+++ b/eval/inference.py
@@ -95,7 +95,10 @@ async def main(args: argparse.Namespace):
             print(f"Table {tab_id} not found in the database. Proceeding with processing.")
 
         gator = Alligator(**args.gator)
-        await gator.run()
+        try:
+            await gator.run()
+        finally:
+            await gator.close()
         toc = time.perf_counter()
         print(f"Processing completed in {toc - tic:0.4f} seconds.")
         perf[table_path] = {"elapsed_time": toc - tic, "nrows": len(table)}

--- a/eval/inference.py
+++ b/eval/inference.py
@@ -1,5 +1,4 @@
 import argparse
-import asyncio
 import os
 import re
 import sys
@@ -18,7 +17,7 @@ from alligator.mongo import MongoWrapper
 load_dotenv(PROJECT_ROOT)
 
 
-async def main(args: argparse.Namespace):
+def main(args: argparse.Namespace):
     perf = {}
     gt = pd.read_csv(
         args.ground_truth,
@@ -135,4 +134,4 @@ if __name__ == "__main__":
     if not os.path.exists(args.tables_dir):
         print(f"Error: Directory {args.tables_dir} does not exist.")
         sys.exit(1)
-    asyncio.run(main(args))
+    main(args)

--- a/eval/inference.py
+++ b/eval/inference.py
@@ -95,10 +95,7 @@ async def main(args: argparse.Namespace):
             print(f"Table {tab_id} not found in the database. Proceeding with processing.")
 
         gator = Alligator(**args.gator)
-        try:
-            await gator.run()
-        finally:
-            await gator.close()
+        gator.run()
         toc = time.perf_counter()
         print(f"Processing completed in {toc - tic:0.4f} seconds.")
         perf[table_path] = {"elapsed_time": toc - tic, "nrows": len(table)}


### PR DESCRIPTION
In this PR, I've added the possibility to create a single `aiohttp.ClientSession` per worker in order to optimize the HTTP calls to LamAPI during the candidate retrieval step.

For a test, on a sample table of 1000 rows and 11 columns (with 4 of them containing named-entities), Alligator takes: 

* W/o cache: 376.2s, i.e.: 
    * 2.65 rows/s 
    * 10.63 mentions/s 
* W/o cache, 1 HTTP-Session per worker: 180.2s 
    * 5.55 rows/s 
    * 22.22 mentions/s 
* W/   cache: 48.2s 
    * 20.75 rows/s 
    * 82.98 mentions/s 

Tested on a MacBook Air M3, using 4 parallel workers for the candidate retriever phase, 2 parallel ML workers, 20 candidates to be retrieved.